### PR TITLE
商品出品一覧の実装

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -465,8 +465,19 @@
       padding: 10px 0;
     }
   }
-  .image {
-    width: 15%;
+  &__image {
+    .item-image{
+      width: 200px;
+      height: 150px;
+    }
+
+    display: flex;
+    justify-content: space-between;
+
+    &--price {
+      display: flex;
+      justify-content: start;
+    }
   }
 }
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -44,5 +44,5 @@ class ImageUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
-  process resize_to_fit: [200, 150]
+  process resize_to_fit: [220, 200]
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -44,5 +44,5 @@ class ImageUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
-  process resize_to_fit: [50, 50]
+  process resize_to_fit: [200, 150]
 end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -93,24 +93,25 @@
       ピックアップカテゴリー
     .pickup__category__box
       .pickup__category__box__sub-title
-        = link_to buyers_path, class: 'pickup__category__box__sub-title' do
+        = link_to root_path, class: 'pickup__category__box__sub-title' do
           新規投稿商品
     .pickup__category__image
-      %ul.pickup__category__image__box
-        %li.pickup__category__image__box__list
-          = link_to buyers_path, class: 'pickup__category__images__box__list' do
-            = image_tag 'icon/daitaidokei.png', class: 'image'
-            = image_tag 'icon/kakarotto.png', class: 'image'
-            = image_tag 'icon/syuzu.png', class: 'image'
-            = image_tag 'icon/carry.png', class: 'image'
-            = image_tag 'icon/kapuriko.png', class: 'image'
-            = image_tag 'icon/carry.png', class: 'image'
+      - @items.each do |item|
+        = link_to buyers_path(item.id) do
+          = image_tag item.item_images.first.image.url ,class: "item-image"
+          .pickup__category__image--name
+            = item.name
+          .pickup__category__image--price
+            = item.price
+            %p 円
+            %p (税込み)
+
   .pickup__brand
     .pickup__brand__title
       ピックアップブランド
     .pickup__brand__box
       .pickup__brand__box__sub-title
-        = link_to buyers_path, class: 'pickup__brand__box__sub-title' do
+        = link_to root_path, class: 'pickup__brand__box__sub-title' do
           アーカイブ
     .pickup__brand__image
       %ul.pickup__brand__image__box
@@ -139,4 +140,4 @@
       .purchase__btn
         出品する
         = image_tag "icon/icon_camera.png" , size: "60x60"
-  = render partial: "render/footer"
+= render partial: "render/footer"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -93,12 +93,12 @@
       ピックアップカテゴリー
     .pickup__category__box
       .pickup__category__box__sub-title
-        = link_to "#", class: 'pickup__category__box__sub-title' do
+        = link_to buyers_path, class: 'pickup__category__box__sub-title' do
           新規投稿商品
     .pickup__category__image
       %ul.pickup__category__image__box
         %li.pickup__category__image__box__list
-          = link_to "#", class: 'pickup__category__images__box__list' do
+          = link_to buyers_path, class: 'pickup__category__images__box__list' do
             = image_tag 'icon/daitaidokei.png', class: 'image'
             = image_tag 'icon/kakarotto.png', class: 'image'
             = image_tag 'icon/syuzu.png', class: 'image'
@@ -110,12 +110,12 @@
       ピックアップブランド
     .pickup__brand__box
       .pickup__brand__box__sub-title
-        = link_to "#", class: 'pickup__brand__box__sub-title' do
+        = link_to buyers_path, class: 'pickup__brand__box__sub-title' do
           アーカイブ
     .pickup__brand__image
       %ul.pickup__brand__image__box
         %li.pickup__brand__image__box__list
-          = link_to "#", class: 'pickup__brand__images__box__list' do
+          = link_to buyers_path, class: 'pickup__brand__images__box__list' do
             = image_tag 'icon/daitaidokei.png', class: 'image'
             = image_tag 'icon/kakarotto.png', class: 'image'
             = image_tag 'icon/syuzu.png', class: 'image'

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -111,7 +111,7 @@
     .pickup__brand__box
       .pickup__brand__box__sub-title
         = link_to "#", class: 'pickup__brand__box__sub-title' do
-          アーカイバ
+          アーカイブ
     .pickup__brand__image
       %ul.pickup__brand__image__box
         %li.pickup__brand__image__box__list


### PR DESCRIPTION
What 
1.アーカイバをアーカイブに修正しました。

2.画像をクリックすると商品購入ページに飛ぶ様にリンク先を設定。

3.each文を使って出品した画像、商品名、値段を実装。画像サイズはuploaderのsizeで微調済。

Why
1.見本がアーカイブになっていたから。

2.購入画面にリンクしないと購入ができないからリンク先を指定しました。

3.モデルを介してDBをeach文で全て表示させたいから。画像サイズは初期設定だと小さすぎて見えなかった為。